### PR TITLE
Add backup shell for Unix OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is a tool to back up the article of the specified account.
 pip install requests
 ```
 
-## Usage
+## Usage(Windows)
 
 #### 1. Git clone
 ```sh
@@ -41,6 +41,26 @@ backup.bat
 [OK!] BBBBB
 [OK!] CCCCC
 ```
+
+## Usage(macOS, Linux)
+
+#### 1. Git clone
+```sh
+git clone https://github.com/i-tanaka730/qiita_backupper
+```
+
+#### 2. Run bachup.sh
+```sh
+$ ./backup.sh $ACCOUNT_NAME $FORMAT
+[OK!] AAAAA
+[OK!] BBBBB
+[OK!] CCCCC
+```
+
+|Arguments|Details|
+|:---:|:---|
+|$USER_NAME|Your account neme of Qiita|
+|$FORMAT|all / md / html|
 
 ## License
 [MIT](https://github.com/i-tanaka730/qiita_backupper/blob/master/LICENSE)

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+python qiita_backupper.py $1 $2


### PR DESCRIPTION
Unix系OSでシェルを自動実行するcrontabとの相性を考慮してユーザー名とフォーマットは引数で与える仕様にさせて頂きました。また、READMEに操作方法を追記しています。